### PR TITLE
Use DynamoDB Local and Tomcat Maven Plugin for local development.

### DIFF
--- a/samples/dynamodb-geo-ios/dynamodb-geo-ios/AWSConstants.m
+++ b/samples/dynamodb-geo-ios/dynamodb-geo-ios/AWSConstants.m
@@ -15,7 +15,7 @@
 
 #import "AWSConstants.h"
 
-NSString *const AWSElasticBeanstalkEndpoint = @"http://YOUR-ENVIRONMENT.elasticbeanstalk.com/dynamodb-geo";
+NSString *const AWSElasticBeanstalkEndpoint = @"http://localhost:9090/dynamodb-geo";
 
 @implementation AWSConstants
 

--- a/samples/dynamodb-geo-server/pom.xml
+++ b/samples/dynamodb-geo-server/pom.xml
@@ -103,6 +103,37 @@
 						</webResources>
 					</configuration>
 				</plugin>
+				<plugin>
+					<groupId>org.apache.tomcat.maven</groupId>
+					<artifactId>tomcat7-maven-plugin</artifactId>
+					<version>2.2</version>
+					<configuration>
+						<!-- http port -->
+						<port>9090</port>
+						<!-- application path always starts with /-->
+						<path>/</path>
+						<!-- optional path to a context file -->
+						<contextFile>${tomcatContextXml}</contextFile>
+						<!-- optional system propoerties you want to add -->
+                        <systemProperties>
+							<!--
+                            <AWS_ACCESS_KEY_ID>AKIAJBG2H2TJ5DSDOS6A</AWS_ACCESS_KEY_ID>
+							<AWS_SECRET_KEY>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</AWS_SECRET_KEY> -->
+							<AWS_ACCESS_KEY_ID>XXXXXXXXX</AWS_ACCESS_KEY_ID>
+							<AWS_SECRET_KEY>YYYYYYYYY</AWS_SECRET_KEY>
+							<PARAM1>geo-test</PARAM1>
+							<PARAM2>us-east-1</PARAM2>
+							<is_local>true</is_local>
+                        </systemProperties>
+						<!-- if you want to use test dependencies rather than only runtime -->
+						<useTestClasspath>false</useTestClasspath>
+						<!-- optional if you want to add some extra directories into the classloader -->
+						<additionalClasspathDirs>
+							<additionalClasspathDir></additionalClasspathDir>
+						</additionalClasspathDirs>
+					</configuration>
+
+				</plugin>
 			</plugins>
 		</pluginManagement>
 
@@ -120,6 +151,7 @@
 					</execution>
 				</executions>
 			</plugin>
+
 		</plugins>
 	</build>
 

--- a/samples/dynamodb-geo-server/src/main/java/com/amazonaws/geo/server/GeoDynamoDBServlet.java
+++ b/samples/dynamodb-geo-server/src/main/java/com/amazonaws/geo/server/GeoDynamoDBServlet.java
@@ -83,15 +83,21 @@ public class GeoDynamoDBServlet extends HttpServlet {
 	}
 
 	private void setupGeoDataManager() {
+		System.out.println("setup");
 		String accessKey = System.getProperty("AWS_ACCESS_KEY_ID");
 		String secretKey = System.getProperty("AWS_SECRET_KEY");
 		String tableName = System.getProperty("PARAM1");
 		String regionName = System.getProperty("PARAM2");
-
 		AWSCredentials credentials = new BasicAWSCredentials(accessKey, secretKey);
+
 		AmazonDynamoDBClient ddb = new AmazonDynamoDBClient(credentials);
 		Region region = Region.getRegion(Regions.fromName(regionName));
 		ddb.setRegion(region);
+
+		if(System.getProperties().containsKey("is_local")) {
+			System.out.println("local");
+			ddb.setEndpoint("http://localhost:8000");
+		}
 
 		config = new GeoDataManagerConfiguration(ddb, tableName);
 		geoDataManager = new GeoDataManager(config);

--- a/samples/dynamodb-geo-server/src/main/java/com/amazonaws/geo/server/util/Utilities.java
+++ b/samples/dynamodb-geo-server/src/main/java/com/amazonaws/geo/server/util/Utilities.java
@@ -65,6 +65,10 @@ public class Utilities {
 		return regionName != null && regionName.length() > 0;
 	}
 
+	public boolean isRunningLocal() {
+		return System.getProperties().containsKey("is_local");
+	}
+
 	public void setupTable() {
 		setupGeoDataManager();
 
@@ -97,6 +101,10 @@ public class Utilities {
 
 			AmazonDynamoDBClient ddb = new AmazonDynamoDBClient(credentials, clientConfiguration);
 			ddb.setRegion(region);
+
+			if(isRunningLocal()) {
+				ddb.setEndpoint("http://localhost:8000");
+			}
 
 			GeoDataManagerConfiguration config = new GeoDataManagerConfiguration(ddb, tableName);
 			geoDataManager = new GeoDataManager(config);


### PR DESCRIPTION
System properties are set in dynamodb-geo-server/pom.xml in the tomcat plugin configuration. If is_local is defined the servlet will try to connect to a DynamoDB local instance on the default port. You can also use this to run the tomcat instance locally instead of using elastic beanstalk.

The server can be run by executing 'mvn tomcat7:run' and will listen on localhost:9090
